### PR TITLE
fix: prevent popup from being placed at sub-pixels when devicePixelRatio is not integer

### DIFF
--- a/src/__tests__/overlays.test.ts
+++ b/src/__tests__/overlays.test.ts
@@ -20,11 +20,11 @@ describe('overlayTransform', () => {
 
     const res = overlayTransform(overlayProps);
 
-    expect(res).toEqual([
-      'translate(1000px, 2000px)',
-      'translate(10px, 20px)',
-      'translate(-50%, 0)'
-    ]);
+    expect(res).toEqual({
+      top: 2020,
+      left: 1010,
+      transform: 'translate(-50%, 0)'
+    });
   });
 
   it('Should transform position and offset only', () => {
@@ -35,7 +35,11 @@ describe('overlayTransform', () => {
 
     const res = overlayTransform(overlayProps);
 
-    expect(res).toEqual(['translate(1000px, 2000px)', 'translate(10px, 20px)']);
+    expect(res).toEqual({
+      left: 1010,
+      top: 2020,
+      transform: 'translate(0, 0)'
+    });
   });
 
   it('Should not add an undefined offset', () => {
@@ -46,7 +50,11 @@ describe('overlayTransform', () => {
 
     const res = overlayTransform(overlayProps);
 
-    expect(res).toEqual(['translate(1000px, 2000px)']);
+    expect(res).toEqual({
+      left: 1000,
+      top: 2000,
+      transform: 'translate(0, 0)'
+    });
   });
 
   it('Should add offset of 0', () => {
@@ -57,6 +65,10 @@ describe('overlayTransform', () => {
 
     const res = overlayTransform(overlayProps);
 
-    expect(res).toEqual(['translate(1000px, 2000px)', 'translate(0px, 20px)']);
+    expect(res).toEqual({
+      left: 1000,
+      top: 2020,
+      transform: 'translate(0, 0)'
+    });
   });
 });

--- a/src/projected-layer.tsx
+++ b/src/projected-layer.tsx
@@ -109,27 +109,36 @@ export default class ProjectedLayer extends React.Component<
       tabIndex
     } = this.props;
     const { anchor } = this.state;
+    const { left, top, transform } = overlayTransform(this.state);
     const finalStyle = {
       ...defaultStyle,
       ...style,
-      transform: overlayTransform(this.state).join(' ')
+      transform
+    };
+    const containerStyle: React.CSSProperties = {
+      position: 'absolute',
+      width: '100%',
+      top,
+      left
     };
     const anchorClassname =
       anchor && type === 'popup' ? `mapboxgl-popup-anchor-${anchor}` : '';
     return (
-      <div
-        className={`${className} ${anchorClassname}`}
-        onClick={onClick}
-        onDoubleClick={onDoubleClick}
-        onMouseEnter={onMouseEnter}
-        onMouseLeave={onMouseLeave}
-        onScroll={onScroll}
-        onWheel={onWheel}
-        style={finalStyle}
-        ref={this.setContainer}
-        tabIndex={tabIndex}
-      >
-        {children}
+      <div style={containerStyle}>
+        <div
+          className={`${className} ${anchorClassname}`}
+          onClick={onClick}
+          onDoubleClick={onDoubleClick}
+          onMouseEnter={onMouseEnter}
+          onMouseLeave={onMouseLeave}
+          onScroll={onScroll}
+          onWheel={onWheel}
+          style={finalStyle}
+          ref={this.setContainer}
+          tabIndex={tabIndex}
+        >
+          {children}
+        </div>
       </div>
     );
   }

--- a/src/util/overlays.ts
+++ b/src/util/overlays.ts
@@ -194,27 +194,27 @@ export const overlayState = (
   };
 };
 
-const moveTranslate = (point: Point) =>
-  point ? `translate(${point.x.toFixed(0)}px, ${point.y.toFixed(0)}px)` : '';
-
 export const overlayTransform = ({
   anchor,
   position,
   offset
-}: OverlayParams) => {
-  const res = [];
+}: OverlayParams): { left: number; top: number; transform: string } => {
+  let left = 0;
+  let top = 0;
 
   if (position) {
-    res.push(moveTranslate(position));
+    left += position.x;
+    top += position.y;
   }
 
   if (offset && offset.x !== undefined && offset.y !== undefined) {
-    res.push(moveTranslate(offset));
+    left += offset.x;
+    top += offset.y;
   }
 
-  if (anchor) {
-    res.push(anchorTranslates[anchor]);
-  }
-
-  return res;
+  return {
+    top,
+    left,
+    transform: anchorTranslates[anchor || 'top-left']
+  };
 };


### PR DESCRIPTION
Egész pixelekre igazítja a popupokat, ezzel megakadályozva a homályossá válást.