### PR TITLE
Fix: factory parameters

### DIFF
--- a/src/map.tsx
+++ b/src/map.tsx
@@ -95,6 +95,8 @@ export interface FactoryParameters {
   bearingSnap?: number;
   injectCss?: boolean;
   transformRequest?: RequestTransformFunction;
+  fadeDuration?: number;
+  crossSourceCollisions?: boolean;
 }
 
 // Satisfy typescript pitfall with defaultProps
@@ -111,6 +113,8 @@ declare global {
     export interface MapboxOptions {
       failIfMajorPerformanceCaveat?: boolean;
       transformRequest?: RequestTransformFunction;
+      fadeDuration?: number;
+      crossSourceCollisions?: boolean;
     }
   }
 }
@@ -139,7 +143,9 @@ const ReactMapboxFactory = ({
   classes,
   bearingSnap = 7,
   injectCss = true,
-  transformRequest
+  transformRequest,
+  fadeDuration = 300,
+  crossSourceCollisions = true
 }: FactoryParameters) => {
   if (injectCss) {
     injectCSS(window);
@@ -236,7 +242,9 @@ const ReactMapboxFactory = ({
         classes,
         bearingSnap,
         failIfMajorPerformanceCaveat,
-        transformRequest
+        transformRequest,
+        fadeDuration,
+        crossSourceCollisions
       };
 
       if (bearing) {


### PR DESCRIPTION
Elérhetővé teszi a `fadeDuration` és `crossSourceCollisions` opciókat a `ReactMapboxFactory`-ban.

NOTE: a vonatkozó paraméterek az upstreamben sincsenek benne, így ezt később oda is betolhatjuk, ld.: https://github.com/alex3165/react-mapbox-gl/blob/master/src/map.tsx#L98